### PR TITLE
Change database engine to postgres

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,6 @@
 
 # Ignore master key for decrypting credentials and more.
 /config/master.key
+
+# Ignore database
+/config/database.yml

--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,7 @@ source "https://rubygems.org"
 git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
 ruby "3.0.3"
-
+gem "pg"
 gem 'sass-rails'
 # Bundle edge Rails instead: gem "rails", github: "rails/rails", branch: "main"
 gem "rails", "~> 7.0.2", ">= 7.0.2.2"
@@ -10,8 +10,8 @@ gem "rails", "~> 7.0.2", ">= 7.0.2.2"
 # The original asset pipeline for Rails [https://github.com/rails/sprockets-rails]
 gem "sprockets-rails"
 
-# Use sqlite3 as the database for Active Record
-gem "sqlite3", "~> 1.4"
+# Use pg as the database for Active Record
+gem "pg", "~> 1.1"
 
 # Use the Puma web server [https://github.com/puma/puma]
 gem "puma", "~> 5.0"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -136,6 +136,10 @@ GEM
       racc (~> 1.4)
     nokogiri (1.13.3-x64-mingw32)
       racc (~> 1.4)
+    nokogiri (1.13.3-x86_64-linux)
+      racc (~> 1.4)
+    pg (1.3.3)
+    pg (1.3.3-x64-mingw32)
     public_suffix (4.0.6)
     puma (5.6.2)
       nio4r (~> 2.0)
@@ -231,6 +235,7 @@ GEM
 PLATFORMS
   arm64-darwin-21
   x64-mingw32
+  x86_64-linux
 
 DEPENDENCIES
   bootsnap
@@ -238,10 +243,10 @@ DEPENDENCIES
   debug
   importmap-rails
   jbuilder
+  pg
   puma (~> 5.0)
   rails (~> 7.0.2, >= 7.0.2.2)
   sass-rails
-  sassc-rails
   selenium-webdriver
   sprockets-rails
   sqlite3 (~> 1.4)

--- a/config/database.example.yml
+++ b/config/database.example.yml
@@ -23,7 +23,7 @@ default: &default
 
 development:
   <<: *default
-  database: kata_07_reloj_checador_k7_f22_t2_development
+  database: (name_of_database)_development
 
   # The specified database role being used to connect to postgres.
   # To create additional roles in postgres see `$ createuser --help`.
@@ -57,7 +57,7 @@ development:
 # Do not set this db to the same as development or production.
 test:
   <<: *default
-  database: kata_07_reloj_checador_k7_f22_t2_test
+  database: (name_of_database)_test
 
 # As with config/credentials.yml, you never want to store sensitive information,
 # like your database password, in your source code. If your source code is
@@ -82,5 +82,5 @@ test:
 production:
   <<: *default
   database: kata_07_reloj_checador_k7_f22_t2_production
-  username: kata_07_reloj_checador_k7_f22_t2
-  password: <%= ENV["KATA_07_RELOJ_CHECADOR_K7_F22_T2_DATABASE_PASSWORD"] %>
+  username: (Username)
+  password: (Password)


### PR DESCRIPTION
# Description
- What?: We change the database engine from sqlite3 to postgres 
- Why?: To start creating the employee, branch and attendance tables

 # Testing
No testing required.